### PR TITLE
Add JEI catalyst for compat crates, register their recipes, minor cleanups

### DIFF
--- a/src/main/java/quaternary/botaniatweaks/modules/avaritia/ModuleAvaritia.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/avaritia/ModuleAvaritia.java
@@ -63,7 +63,7 @@ public class ModuleAvaritia implements IModule {
 				direCrate = new BlockCompatCrate(direCrateEntry, TileDireCraftyCrate::new);
 				reg.register(RegHelpers.createBlock(direCrate, "dire_crafty_crate"));
 				
-				GameRegistry.registerTileEntity(TileDireCraftyCrate.class, BotaniaTweaks.MODID + ":dire_crafty_crate");
+				GameRegistry.registerTileEntity(TileDireCraftyCrate.class, new ResourceLocation(BotaniaTweaks.MODID, "dire_crafty_crate"));
 			}
 		}
 		

--- a/src/main/java/quaternary/botaniatweaks/modules/botania/ModuleBotania.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/botania/ModuleBotania.java
@@ -8,6 +8,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.client.event.ModelRegistryEvent;
 import net.minecraftforge.common.MinecraftForge;
@@ -152,10 +153,10 @@ public class ModuleBotania implements IModule {
 			pottedTater = RegHelpers.createBlock(new BlockPottedTinyPotato(), "potted_tiny_potato");
 			reg.register(pottedTater);
 			
-			GameRegistry.registerTileEntity(TileNerfedManaFluxfield.class, BotaniaTweaks.MODID + ":tweaked_fluxfield");
-			GameRegistry.registerTileEntity(TileCustomAgglomerationPlate.class, BotaniaTweaks.MODID + ":custom_agglomeration_plate");
-			GameRegistry.registerTileEntity(TileCompressedTinyPotato.class, BotaniaTweaks.MODID + ":compressed_tiny_potato");
-			GameRegistry.registerTileEntity(TileCustomCraftyCrate.class, BotaniaTweaks.MODID + ":custom_crafty_crate");
+			GameRegistry.registerTileEntity(TileNerfedManaFluxfield.class,      new ResourceLocation(BotaniaTweaks.MODID, "tweaked_fluxfield"));
+			GameRegistry.registerTileEntity(TileCustomAgglomerationPlate.class, new ResourceLocation(BotaniaTweaks.MODID, "custom_agglomeration_plate"));
+			GameRegistry.registerTileEntity(TileCompressedTinyPotato.class,     new ResourceLocation(BotaniaTweaks.MODID, "compressed_tiny_potato"));
+			GameRegistry.registerTileEntity(TileCustomCraftyCrate.class,        new ResourceLocation(BotaniaTweaks.MODID, "custom_crafty_crate"));
 		}
 		
 		@SubscribeEvent

--- a/src/main/java/quaternary/botaniatweaks/modules/botania/block/BlockCompressedTinyPotato.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/botania/block/BlockCompressedTinyPotato.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.*;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -12,7 +13,6 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
@@ -62,7 +62,7 @@ public class BlockCompressedTinyPotato extends Block implements ILexiconable {
 	@SideOnly(Side.CLIENT)
 	public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> tooltip, ITooltipFlag flagIn) {
 		String nicePotatoCount = String.format("%,d", potatoCount);
-		tooltip.add(I18n.translateToLocalFormatted("botania_tweaks.compressedpotato.tooltip", nicePotatoCount));
+		tooltip.add(I18n.format("botania_tweaks.compressedpotato.tooltip", nicePotatoCount));
 	}
 	
 	@Override
@@ -116,22 +116,26 @@ public class BlockCompressedTinyPotato extends Block implements ILexiconable {
 	
 	//Render
 	@Override
+	@Deprecated
 	public EnumBlockRenderType getRenderType(IBlockState state) {
 		return EnumBlockRenderType.ENTITYBLOCK_ANIMATED;
 	}
 	
 	@Override
+	@Deprecated
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 	
 	@Override
+	@Deprecated
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
 	
 	//State
 	@Override
+	@Deprecated
 	public IBlockState getStateFromMeta(int meta) {
 		return getDefaultState().withProperty(FACING, EnumFacing.byHorizontalIndex(meta));
 	}
@@ -147,17 +151,20 @@ public class BlockCompressedTinyPotato extends Block implements ILexiconable {
 	}
 	
 	@Override
+	@Deprecated
 	public IBlockState getStateForPlacement(World worldIn, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer) {
 		return getDefaultState().withProperty(FACING, placer.getHorizontalFacing().getOpposite());
 	}
 	
 	//Etc
 	@Override
+	@Deprecated
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
 		return aabb;
 	}
 	
 	@Override
+	@Deprecated
 	public BlockFaceShape getBlockFaceShape(IBlockAccess worldIn, IBlockState state, BlockPos pos, EnumFacing face) {
 		if(compressionLevel != 8) return BlockFaceShape.UNDEFINED;
 		else return face == EnumFacing.UP ? BlockFaceShape.UNDEFINED : BlockFaceShape.SOLID;

--- a/src/main/java/quaternary/botaniatweaks/modules/botania/block/BlockNerfedManaFluxfield.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/botania/block/BlockNerfedManaFluxfield.java
@@ -13,28 +13,27 @@ import quaternary.botaniatweaks.modules.botania.tile.TileNerfedManaFluxfield;
 import vazkii.botania.api.lexicon.ILexiconable;
 import vazkii.botania.common.block.mana.BlockRFGenerator;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 public class BlockNerfedManaFluxfield extends BlockRFGenerator implements ILexiconable, IBotaniaTweaked {
-	public BlockNerfedManaFluxfield() {
-		
-	}
 	
-	@Nullable
+	@Nonnull
 	@Override
 	public TileEntity createTileEntity(World world, IBlockState state) {
 		return new TileNerfedManaFluxfield();
 	}
-	
+
 	@Override
+	@Deprecated
 	public boolean hasComparatorInputOverride(IBlockState state) {
 		return true;
 	}
-	
+
 	@CapabilityInject(IEnergyStorage.class)
 	public static final Capability<IEnergyStorage> ENERGY_CAP = null;
 	
 	@Override
+	@Deprecated
 	public int getComparatorInputOverride(IBlockState blockState, World world, BlockPos pos) {
 		TileEntity tile = world.getTileEntity(pos);
 		if(tile instanceof TileNerfedManaFluxfield) {

--- a/src/main/java/quaternary/botaniatweaks/modules/botania/block/BlockPottedTinyPotato.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/botania/block/BlockPottedTinyPotato.java
@@ -34,16 +34,19 @@ public class BlockPottedTinyPotato extends Block {
 	}
 	
 	@Override
+	@Deprecated
 	public AxisAlignedBB getBoundingBox(IBlockState state, IBlockAccess source, BlockPos pos) {
 		return FLOWER_POT_AABB;
 	}
 	
 	@Override
+	@Deprecated
 	public boolean isOpaqueCube(IBlockState state) {
 		return false;
 	}
 	
 	@Override
+	@Deprecated
 	public boolean isFullCube(IBlockState state) {
 		return false;
 	}
@@ -71,6 +74,7 @@ public class BlockPottedTinyPotato extends Block {
 	}
 	
 	@Override
+	@Deprecated
 	public IBlockState getStateForPlacement(World worldIn, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer) {
 		return getDefaultState().withProperty(POTATO_FACING, placer.getHorizontalFacing().getOpposite());
 	}
@@ -81,11 +85,13 @@ public class BlockPottedTinyPotato extends Block {
 	
 	//and the blockstate boiler plate
 	@Override
+	@Deprecated
 	protected BlockStateContainer createBlockState() {
 		return new BlockStateContainer(this, POTATO_FACING);
 	}
 	
 	@Override
+	@Deprecated
 	public IBlockState getStateFromMeta(int meta) {
 		return getDefaultState().withProperty(POTATO_FACING, EnumFacing.byHorizontalIndex(meta));
 	}
@@ -97,6 +103,7 @@ public class BlockPottedTinyPotato extends Block {
 	
 	//bleh
 	@Override
+	@Deprecated
 	public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
 		return BlockFaceShape.UNDEFINED;
 	}

--- a/src/main/java/quaternary/botaniatweaks/modules/botania/handler/TooltipHandler.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/botania/handler/TooltipHandler.java
@@ -1,9 +1,9 @@
 package quaternary.botaniatweaks.modules.botania.handler;
 
 import net.minecraft.block.Block;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.item.*;
 import net.minecraft.util.text.TextFormatting;
-import net.minecraft.util.text.translation.I18n;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import quaternary.botaniatweaks.asm.BotaniaTweakerHooks;
@@ -37,7 +37,7 @@ public class TooltipHandler {
 		}
 		
 		if(addTooltip) {
-			e.getToolTip().add(TextFormatting.DARK_GRAY + "" + TextFormatting.ITALIC + I18n.translateToLocal("botania_tweaks.tweaked") + TextFormatting.RESET);
+			e.getToolTip().add(TextFormatting.DARK_GRAY + "" + TextFormatting.ITALIC + I18n.format("botania_tweaks.tweaked") + TextFormatting.RESET);
 		}
 	}
 }

--- a/src/main/java/quaternary/botaniatweaks/modules/extendedcrafting/ModuleExtendedCrafting.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/extendedcrafting/ModuleExtendedCrafting.java
@@ -50,7 +50,7 @@ public class ModuleExtendedCrafting implements IModule {
 				ItemStack extTableStack = new ItemStack(Item.getItemFromBlock(extTable));
 				ItemStack crateStack = ModCompatUtil.getStackFor(new ResourceLocation("botania", "opencrate"), 1);
 				
-				elvenRecipes.add(new RecipeElvenTrade(new ItemStack[] {extCrateStack}, extTableStack, crateStack));
+				elvenRecipes.add(BotaniaAPI.registerElvenTradeRecipe(extCrateStack, extTableStack, crateStack));
 			};
 			
 			elvenRecipeFunc.accept(basicExtCrate, ModBlocks.blockBasicTable);
@@ -89,10 +89,10 @@ public class ModuleExtendedCrafting implements IModule {
 				reg.register(RegHelpers.createBlock(eliteExtCrate, "elite_extended_crafty_crate"));
 				reg.register(RegHelpers.createBlock(ultExtCrate, "ultimate_extended_crafty_crate"));
 				
-				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Basic.class, BotaniaTweaks.MODID + ":basic_ext_crafty_crate");
-				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Advanced.class, BotaniaTweaks.MODID + ":adv_ext_crafty_crate");
-				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Elite.class, BotaniaTweaks.MODID + ":elite_ext_crafty_crate");
-				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Ultimate.class, BotaniaTweaks.MODID + ":ult_ext_crafty_crate");
+				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Basic.class,    new ResourceLocation(BotaniaTweaks.MODID, "basic_ext_crafty_crate"));
+				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Advanced.class, new ResourceLocation(BotaniaTweaks.MODID, "adv_ext_crafty_crate"));
+				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Elite.class,    new ResourceLocation(BotaniaTweaks.MODID, "elite_ext_crafty_crate"));
+				GameRegistry.registerTileEntity(AbstractTileExtCraftCrate.Ultimate.class, new ResourceLocation(BotaniaTweaks.MODID, "ult_ext_crafty_crate"));
 			}
 		}
 		

--- a/src/main/java/quaternary/botaniatweaks/modules/jei/BotaniaTweaksJeiPlugin.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/jei/BotaniaTweaksJeiPlugin.java
@@ -5,9 +5,12 @@ import mezz.jei.api.recipe.IRecipeCategoryRegistration;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import quaternary.botaniatweaks.BotaniaTweaks;
 import quaternary.botaniatweaks.modules.botania.recipe.AgglomerationRecipe;
 import quaternary.botaniatweaks.modules.botania.recipe.AgglomerationRecipes;
+import quaternary.botaniatweaks.modules.shared.helper.ModCompatUtil;
 
 @JEIPlugin
 public class BotaniaTweaksJeiPlugin implements IModPlugin {
@@ -24,5 +27,15 @@ public class BotaniaTweaksJeiPlugin implements IModPlugin {
 		
 		Item terraPlate = ForgeRegistries.ITEMS.getValue(new ResourceLocation("botania", "terraplate"));
 		registry.addRecipeCatalyst(new ItemStack(terraPlate), RecipeCategoryCustomAgglomeration.UID);
+
+		if(Loader.isModLoaded("extendedcrafting")) {
+			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "basic_extended_crafty_crate")), "extendedcrafting:table_crafting_3x3");
+			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "advanced_extended_crafty_crate")), "extendedcrafting:table_crafting_5x5");
+			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "elite_extended_crafty_crate")), "extendedcrafting:table_crafting_7x7");
+			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "ultimate_extended_crafty_crate")), "extendedcrafting:table_crafting_9x9");
+		}
+		if(Loader.isModLoaded("avaritia")) {
+			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "dire_crafty_crate")), "Avatitia.Extreme");
+		}
 	}
 }

--- a/src/main/java/quaternary/botaniatweaks/modules/jei/RecipeCategoryCustomAgglomeration.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/jei/RecipeCategoryCustomAgglomeration.java
@@ -4,12 +4,13 @@ import com.google.common.collect.ImmutableList;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.*;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.text.translation.I18n;
 import quaternary.botaniatweaks.BotaniaTweaks;
 import quaternary.botaniatweaks.modules.shared.helper.ModCompatUtil;
 
@@ -25,7 +26,7 @@ public class RecipeCategoryCustomAgglomeration implements IRecipeCategory {
 	final IDrawable background;
 	
 	public RecipeCategoryCustomAgglomeration(IGuiHelper guiHelper) {
-		localizedName = I18n.translateToLocal("botania_tweaks.jei.agglomeration.category");
+		localizedName = I18n.format("botania_tweaks.jei.agglomeration.category");
 		background = guiHelper.createDrawable(new ResourceLocation(BotaniaTweaks.MODID, "textures/ui/terrasteeloverlay.png"), 0, 0, WIDTH, HEIGHT);
 	}
 	
@@ -60,9 +61,9 @@ public class RecipeCategoryCustomAgglomeration implements IRecipeCategory {
 		RecipeWrapperAgglomeration wrapper = (RecipeWrapperAgglomeration) wrap;
 		
 		IGuiItemStackGroup stacks = layout.getItemStacks();
-		List<List<ItemStack>> ins = ings.getInputs(ItemStack.class);
+		List<List<ItemStack>> ins = ings.getInputs(VanillaTypes.ITEM);
 		List<List<ItemStack>> itemInputs = ins.subList(0, ins.size() - 3);
-		List<List<ItemStack>> outs = ings.getOutputs(ItemStack.class);
+		List<List<ItemStack>> outs = ings.getOutputs(VanillaTypes.ITEM);
 		int index = 0;
 		
 		//Set centered row of inputs

--- a/src/main/java/quaternary/botaniatweaks/modules/jei/RecipeWrapperAgglomeration.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/jei/RecipeWrapperAgglomeration.java
@@ -2,6 +2,7 @@ package quaternary.botaniatweaks.modules.jei;
 
 import com.google.common.collect.ImmutableList;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeWrapper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
@@ -89,8 +90,8 @@ public class RecipeWrapperAgglomeration implements IRecipeWrapper {
 	
 	@Override
 	public void getIngredients(IIngredients ing) {
-		ing.setInputLists(ItemStack.class, inputs);
-		ing.setOutputs(ItemStack.class, outputs);
+		ing.setInputLists(VanillaTypes.ITEM, inputs);
+		ing.setOutputs(VanillaTypes.ITEM, outputs);
 	}
 	
 	@Override

--- a/src/main/java/quaternary/botaniatweaks/modules/jei/package-info.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/jei/package-info.java
@@ -1,0 +1,3 @@
+@javax.annotation.ParametersAreNonnullByDefault
+@mcp.MethodsReturnNonnullByDefault
+package quaternary.botaniatweaks.modules.jei;

--- a/src/main/java/quaternary/botaniatweaks/modules/shared/config/ConfigUpdater.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/shared/config/ConfigUpdater.java
@@ -7,7 +7,7 @@ import org.apache.logging.log4j.Logger;
 import quaternary.botaniatweaks.BotaniaTweaks;
 
 public class ConfigUpdater {
-	public static final int CONFIG_FILE_VERSION = 3;
+	public static final int CONFIG_FILE_VERSION = 4;
 	
 	private static final Logger LOG = LogManager.getLogger(BotaniaTweaks.NAME + " Config Auto-Updater");
 	
@@ -42,13 +42,19 @@ public class ConfigUpdater {
 			version = 3;
 			dirtyConfig = true;
 		}
-		
+
+		if(version <= 3) {
+			updatev3tov4(config);
+			version = 4;
+			dirtyConfig = true;
+		}
+
 		if(dirtyConfig) {
 			BotaniaTweaksConfig.readConfig();
 		}
 	}
-	
-	static void updatev1tov2(Configuration config) {
+
+	private static void updatev1tov2(Configuration config) {
 		log("Updating version 1 config to version 2");
 		//dootable agricraft to new location
 		if(config.hasKey("compat", "dootableAgricraft")) {
@@ -88,12 +94,20 @@ public class ConfigUpdater {
 			config.getCategory("etc").remove("pottedTinyPotato");
 		}
 	}
-	
-	static void updatev2tov3(Configuration config) {
+
+	private static void updatev2tov3(Configuration config) {
 		log("Updating version 2 config to version 3");
 		if(config.hasKey("balance.decay.flowers", "hydroangeasDecay")) {
 			log("Removing mistakenly-added hydroangeas decay configuration");
 			config.getCategory("balance.decay.flowers").remove("hydroangeasDecay");
+		}
+	}
+
+	private static void updatev3tov4(Configuration config) {
+		log("Updating version 3 config to version 4");
+		if(config.hasCategory("compat.agricraft")) {
+			log("Removing Agricraft compat category, since it was removed after Agricraft added horn compat");
+			config.removeCategory(config.getCategory("compat.agricraft"));
 		}
 	}
 }


### PR DESCRIPTION
* Actually register EC compat crate recipes and not just make them to show in the lexicon.
* The most important thing, the crates actually show up in JEI as usable for crafting in those categories. Was literally unplayable before
* Tile entity registration moved from plain strings to resloc
* Deprecate deprecated overrides and use client I18n for clientside I18n
* Silence some nullability complaints in JEI plugin with an annotated package-info
* Remove Agricraft config section from existing configs

Brings down the compile warning numbers from 39 to 2.