### PR TITLE
Fix JEI plugin throwing if compat crates were disabled but available

### DIFF
--- a/src/main/java/quaternary/botaniatweaks/modules/jei/BotaniaTweaksJeiPlugin.java
+++ b/src/main/java/quaternary/botaniatweaks/modules/jei/BotaniaTweaksJeiPlugin.java
@@ -8,8 +8,10 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
 import quaternary.botaniatweaks.BotaniaTweaks;
+import quaternary.botaniatweaks.modules.avaritia.AvaritiaConfig;
 import quaternary.botaniatweaks.modules.botania.recipe.AgglomerationRecipe;
 import quaternary.botaniatweaks.modules.botania.recipe.AgglomerationRecipes;
+import quaternary.botaniatweaks.modules.extendedcrafting.ExtendedCraftingConfig;
 import quaternary.botaniatweaks.modules.shared.helper.ModCompatUtil;
 
 @JEIPlugin
@@ -28,13 +30,13 @@ public class BotaniaTweaksJeiPlugin implements IModPlugin {
 		Item terraPlate = ForgeRegistries.ITEMS.getValue(new ResourceLocation("botania", "terraplate"));
 		registry.addRecipeCatalyst(new ItemStack(terraPlate), RecipeCategoryCustomAgglomeration.UID);
 
-		if(Loader.isModLoaded("extendedcrafting")) {
+		if(Loader.isModLoaded("extendedcrafting") && ExtendedCraftingConfig.EXTENDED_CRAFTY_CRATES) {
 			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "basic_extended_crafty_crate")), "extendedcrafting:table_crafting_3x3");
 			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "advanced_extended_crafty_crate")), "extendedcrafting:table_crafting_5x5");
 			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "elite_extended_crafty_crate")), "extendedcrafting:table_crafting_7x7");
 			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "ultimate_extended_crafty_crate")), "extendedcrafting:table_crafting_9x9");
 		}
-		if(Loader.isModLoaded("avaritia")) {
+		if(Loader.isModLoaded("avaritia") && AvaritiaConfig.DIRE_CRAFTY_CRATE) {
 			registry.addRecipeCatalyst(ModCompatUtil.getStackFor(new ResourceLocation(BotaniaTweaks.MODID, "dire_crafty_crate")), "Avatitia.Extreme");
 		}
 	}


### PR DESCRIPTION
This didn't break the JEI plugin completely or crash the game, only showed a really ugly stack trace and caused the Dire Crafty Crate to not get added as a catalyst if EC was also available and had them disabled.

Did I ever mention I am dumb or anything? At least it doesn't break progression and no one looks in console logs anyways.